### PR TITLE
Add raco fix command

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,8 +21,9 @@ install:
       $TRAVIS_BUILD_DIR/syntax-warn-lang
       $TRAVIS_BUILD_DIR/syntax-warn-test
 script:
-  - raco test -c warn racket/base
-  - if [ -n "$RUN_COVER" ]; then raco cover -f coveralls -d $TRAVIS_BUILD_DIR/coverage -c warn racket/base; fi
+  - raco test -c warn
+  - raco test -c racket/base
+  - if [ -n "$RUN_COVER" ]; then raco cover -f coveralls -d $TRAVIS_BUILD_DIR/coverage -c warn; fi
 after_success:
   - echo "Starting deploy"
   - if [ "${DEPLOY_VERSION}" != "${RACKET_VERSION}" ]; then exit 0; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,9 +21,8 @@ install:
       $TRAVIS_BUILD_DIR/syntax-warn-lang
       $TRAVIS_BUILD_DIR/syntax-warn-test
 script:
-  - raco test -c warn
-  - raco test -c racket/base
-  - if [ -n "$RUN_COVER" ]; then raco cover -f coveralls -d $TRAVIS_BUILD_DIR/coverage -c warn; fi
+  - raco test -c warn racket/base
+  - if [ -n "$RUN_COVER" ]; then raco cover -f coveralls -d $TRAVIS_BUILD_DIR/coverage -c warn racket/base; fi
 after_success:
   - echo "Starting deploy"
   - if [ "${DEPLOY_VERSION}" != "${RACKET_VERSION}" ]; then exit 0; fi

--- a/syntax-warn-test/test.rkt
+++ b/syntax-warn-test/test.rkt
@@ -33,11 +33,11 @@
   (test-case "Checking a module with warnings"
     (define result (run-warn-command "warn/test-warnings"))
     (check-equal? (system-result-code result) 1)
-    (check-equal? (system-result-stderr result) "")
     (check-string-contains-all? (system-result-stdout result)
                                 (list "Checking 1 module\n"
                                       "syntax-warn-test/test-warnings/main.rkt"
                                       "phase order"
                                       "suggested fix"
                                       "require"
-                                      "for-syntax"))))
+                                      "for-syntax"))
+    (check-equal? (system-result-stderr result) "")))

--- a/syntax-warn/info.rkt
+++ b/syntax-warn/info.rkt
@@ -5,4 +5,5 @@
   '(("base" #:version "6.4")))
 (define scribblings '(("main.scrbl" () (library) "warn")))
 (define raco-commands
-  '(("warn" (submod warn/raco-warn main) "Check for syntax warnings" 20)))
+  '(("warn" (submod warn/raco-warn main) "Check for syntax warnings" 20)
+    ("fix" (submod warn/raco-fix main) "Fix syntax warnings" 20)))

--- a/syntax-warn/main.rkt
+++ b/syntax-warn/main.rkt
@@ -64,7 +64,9 @@
     (with-input-from-file modpath #:mode 'text
       (thunk
        (port-count-lines! (current-input-port))
-       (parameterize ([current-namespace (make-base-namespace)])
+       (define-values (moddir _1 _2) (split-path modpath))
+       (parameterize ([current-namespace (make-base-namespace)]
+                      [current-directory moddir])
          (expand-syntax
           (namespace-syntax-introduce
            (read-syntax modpath)))))))

--- a/syntax-warn/main.scrbl
+++ b/syntax-warn/main.scrbl
@@ -4,8 +4,6 @@
 
 @(define (warn-tech . pre-content)
    (apply tech #:key "syntax-warning" #:normalize? #f pre-content))
-@(define-syntax-rule (document-syntax-property-key id pre-flow ...)
-   (defform #:kind "syntax property key" #:id id id pre-flow ...))
 @(define-syntax-rule (syntax-warn-examples example ...)
    (examples #:eval (make-base-eval #:lang 'racket/base '(require warn)) example ...))
 @(define-syntax-rule (document-syntax-parameter id pre-flow ...)
@@ -56,17 +54,11 @@ other code and tools.
  attached. The warning points to @racket[bad-stx] as its source, which defaults to
  @racket[stx] if not provided. The warning has @racket[message] as its message.
  If @racket[replacement-stx] is not @racket[#f], the warning suggests replacing
- @racket[bad-stx] with @racket[replacement-stx]. The warning is added under the
- @racket[syntax-warning-property-key] syntax property.
+ @racket[bad-stx] with @racket[replacement-stx]. The warning is attached via a syntax
+ property whose key is internal to the warnings library.
  @syntax-warn-examples[
  (syntax-warn #'(lambda (lambda) lambda)
               "Shadowing the language defined identifier \"lambda\" is discouraged")]}
-
-@document-syntax-property-key[syntax-warnings-property-key]{
- A value used as the @racket[syntax-property] key that @warn-tech{syntax-warnings}
- are attached to. This value is not guaranteed to remain constant across package
- versions.
- @syntax-warn-examples[syntax-warnings-property-key]}
 
 @defproc[(syntax-warnings [stx syntax?]) (listof syntax?)]{
  Returns a list of all syntax warnings present in @racket[stx]. This includes

--- a/syntax-warn/private/string-delta.rkt
+++ b/syntax-warn/private/string-delta.rkt
@@ -1,0 +1,199 @@
+#lang racket/base
+
+(require racket/contract/base)
+
+(provide
+ (contract-out
+  [struct string-delta
+    ([start exact-nonnegative-integer?]
+     [span exact-nonnegative-integer?]
+     [new-text string?])]
+  [string-delta-end (-> string-delta? exact-nonnegative-integer?)]
+  [prune-string-deltas (-> (listof string-delta?)
+                           (listof string-delta?))]
+  [apply-pruned-string-deltas (-> string? (listof string-delta?)
+                                  string?)]))
+
+(require racket/list
+         "syntax-srcloc.rkt")
+
+(module+ test
+  (require rackunit))
+
+
+(struct string-delta (start span new-text) #:transparent)
+
+(module+ test
+  (define delta (string-delta 10 24 "blah"))
+  (define engulfed (string-delta 12 5 "foo"))
+  (define overlapped (string-delta 30 20 "kdlfjs"))
+  (define before (string-delta 3 5 "klf"))
+  (define after (string-delta 45 23 "lkfdjalkf")))
+  
+
+(define (string-delta-end delta)
+  (+ (string-delta-start delta) (string-delta-span delta)))
+
+(module+ test
+  (check-equal? (string-delta-end delta) 34))
+
+(define ((string-delta-compare compare-proc field-proc) . deltas)
+  (or (empty? deltas)
+      (empty? (rest deltas))
+      (apply compare-proc (map field-proc deltas))))
+
+(define string-delta-start< (string-delta-compare < string-delta-start))
+(define string-delta-start> (string-delta-compare > string-delta-start))
+(define string-delta-start= (string-delta-compare = string-delta-start))
+(define string-delta-start<= (string-delta-compare <= string-delta-start))
+(define string-delta-start>= (string-delta-compare >= string-delta-start))
+(define string-delta-end< (string-delta-compare < string-delta-end))
+(define string-delta-end> (string-delta-compare > string-delta-end))
+(define string-delta-end= (string-delta-compare = string-delta-end))
+(define string-delta-end<= (string-delta-compare <= string-delta-end))
+(define string-delta-end>= (string-delta-compare >= string-delta-end))
+
+(module+ test
+  (test-case "string-delta-start<"
+    (test-true "empty case" (string-delta-start<))
+    (test-true "single argument case" (string-delta-start< delta))
+    (test-case "multi argument cases"
+      (check-true (string-delta-start< delta engulfed))
+      (check-false (string-delta-start< engulfed delta))
+      (check-true (string-delta-start< before delta engulfed overlapped after))
+      (check-false (string-delta-start< before delta overlapped engulfed after)))))
+
+(define (string-delta-engulfs? delta engulfed-delta)
+  (and (string-delta-start<= delta engulfed-delta)
+       (string-delta-end>= delta engulfed-delta)))
+
+(module+ test
+  (test-case "string-delta-engulfs?"
+    (define (test-string-delta-engulfs? test-delta)
+      (string-delta-engulfs? delta test-delta))
+    (define (test-string-delta-engulfs-not? test-delta)
+      (not (string-delta-engulfs? delta test-delta)))
+    (check-pred test-string-delta-engulfs? engulfed)
+    (check-pred test-string-delta-engulfs-not? overlapped)
+    (check-pred test-string-delta-engulfs-not? before)
+    (check-pred test-string-delta-engulfs-not? after)
+    (check-pred test-string-delta-engulfs? delta)))
+
+(define (string-delta-overlaps? delta overlapped-delta)
+  (if (string-delta-start<= delta overlapped-delta)
+      (<= (string-delta-start overlapped-delta)
+          (string-delta-end delta))
+      (string-delta-overlaps? overlapped-delta delta)))
+
+(module+ test
+  (test-case "string-delta-overlaps?"
+    (define (test-string-delta-overlaps? test-delta)
+      (string-delta-overlaps? delta test-delta))
+    (define (test-string-delta-overlaps-not? test-delta)
+      (not (string-delta-overlaps? delta test-delta)))
+    (check-pred test-string-delta-overlaps? engulfed)
+    (check-pred test-string-delta-overlaps? overlapped)
+    (check-pred test-string-delta-overlaps-not? before)
+    (check-pred test-string-delta-overlaps-not? after)
+    (check-pred test-string-delta-overlaps? delta)))
+
+;; Given a list of file deltas, one of them can't be applied if:
+;; - Another delta engulfs it
+;; - Another delta overlaps it
+;; If a delta engulfs another delta, the engulfing delta may be
+;; applied (note this makes engulfs assymetric but overlaps
+;; symmetric w.r.t. pruning)
+(define (prune-string-deltas deltas)
+  (cond
+    [(empty? deltas) '()]
+    [else
+     (define sorted (sort deltas string-delta-start<=))
+     (define (keep? delta previous-delta)
+       (and (not (string-delta-engulfs? previous-delta delta))
+            (not (string-delta-overlaps? previous-delta delta))))
+     (reverse
+      (for/fold ([previous-deltas '()])
+                ([delta (in-list sorted)])
+        (cond
+          [(for/or ([previous-delta (in-list previous-deltas)])
+             (string-delta-engulfs? previous-delta delta))
+           previous-deltas]
+          [(for/or ([previous-delta (in-list previous-deltas)])
+             (string-delta-engulfs? delta previous-delta))
+           (define (keep? previous-delta)
+             (not (string-delta-engulfs? delta previous-delta)))
+           (cons delta (filter keep? previous-deltas))]
+          [(for/or ([previous-delta (in-list previous-deltas)])
+             (string-delta-overlaps? previous-delta delta))
+           (define (keep? previous-delta)
+             (not (string-delta-overlaps? previous-delta delta)))
+           (filter keep? previous-deltas)]
+          [else (cons delta previous-deltas)])))]))
+
+(module+ test
+  (test-case "prune-string-deltas"
+    (define non-overlapping-deltas
+      (list (string-delta 23 3 "kfj")
+            (string-delta 59 24 "flksa")
+            (string-delta 10 4 "dkflaj")))
+    (define non-overlapping-deltas/sorted
+      (list (string-delta 10 4 "dkflaj")
+            (string-delta 23 3 "kfj")
+            (string-delta 59 24 "flksa")))
+    (check-equal? (prune-string-deltas non-overlapping-deltas)
+                  non-overlapping-deltas/sorted)
+    (define engulfed-deltas
+      (list (string-delta 10 40 "sfklaj")
+            (string-delta 20 4 "sklafj")
+            (string-delta 2 6 "slakfj")
+            (string-delta 56 23 "saklfj")))
+    (define engulfed-deltas/sorted+engulfed-removed
+      (list (string-delta 2 6 "slakfj")
+            (string-delta 10 40 "sfklaj")
+            (string-delta 56 23 "saklfj")))
+    (check-equal? (prune-string-deltas engulfed-deltas)
+                  engulfed-deltas/sorted+engulfed-removed)
+    (define overlapped-deltas
+      (list (string-delta 23 10 "ksalfj")
+            (string-delta 18 6 "asfklja")
+            (string-delta 5 10 "asklfjaslf")
+            (string-delta 40 29 "asklfjas")))
+    (define overlapped-deltas/sorted+overlapped-removed
+      (list (string-delta 5 10 "asklfjaslf")
+            (string-delta 40 29 "asklfjas")))
+    (check-equal? (prune-string-deltas overlapped-deltas)
+                  overlapped-deltas/sorted+overlapped-removed)))
+
+(define (apply-pruned-string-deltas str deltas)
+  (cond
+    [(empty? deltas) str]
+    [else
+     (define-values (pieces/reversed last-end)
+       (for/fold ([pieces '()]
+                  [prev-end #f])
+                 ([delta (in-list deltas)])
+         (define start (string-delta-start delta))
+         (define end (string-delta-end delta))
+         (define next-piece (substring str (or prev-end 0) start))
+         (values (cons next-piece pieces) end)))
+     (define last-piece (substring str last-end))
+     (define all-pieces (reverse (cons last-piece pieces/reversed)))
+     (define-values (all-pieces/insertions/reversed _)
+       (for/fold ([all-pieces/insertions/reversed (list (first all-pieces))]
+                  [prev-piece (first all-pieces)])
+                 ([piece (in-list (rest all-pieces))]
+                  [delta (in-list deltas)])
+         (values (list* piece
+                        (string-delta-new-text delta)
+                        all-pieces/insertions/reversed)
+                 piece)))
+     (apply string-append (reverse all-pieces/insertions/reversed))]))
+
+(module+ test
+  (test-case "apply-pruned-string-deltas"
+    (define deltas
+      (list (string-delta 1 5 "REPLACED")
+            (string-delta 8 3 "X")
+            (string-delta 15 5 "FOO")))
+    (check-equal? (apply-pruned-string-deltas "foo bar baz blah bleh" deltas)
+                  "fREPLACEDr X blaFOOh")))

--- a/syntax-warn/private/syntax-string.rkt
+++ b/syntax-warn/private/syntax-string.rkt
@@ -111,4 +111,6 @@
                     )
                bork   fork))
   (check-equal? (syntax->string test-stx)
+                "(  require foo\n         bar\n                 (baz   blah)\n\n               bork   fork)")
+  (check-equal? (syntax->string test-stx #:start-col 0)
                 "      (  require foo\n         bar\n                 (baz   blah)\n\n               bork   fork)"))

--- a/syntax-warn/raco-fix.rkt
+++ b/syntax-warn/raco-fix.rkt
@@ -1,0 +1,89 @@
+#lang racket/base
+
+(require racket/cmdline
+         racket/match
+         raco/command-name
+         "private/module.rkt"
+         "main.rkt")
+
+(struct fix-args (module-args run-mode) #:transparent)
+
+(define (parse-warn-command!)
+  (define kind-param (make-parameter 'file))
+  (define run-mode-param (make-parameter 'wet))
+  (command-line
+   #:program (short-program+command-name)
+   #:once-any
+   ["--arg-kind" kind
+                 ("How to interpret the arguments as modules"
+                  "One of file, directory, collection, or package"
+                  "Defaults to file")
+                 (check-kind! kind)
+                 (kind-param kind)]
+   [("-f" "--file-args") ("Interpret the arguments as files"
+                          "Files are required as modules and checked"
+                          "Equivalent to \"--arg-kind file\", default behavior")
+                         (kind-param 'file)]
+   [("-d" "--directory-args") ("Interpret the arguments as directories"
+                               "Modules in directories are recursively checked"
+                               "Equivalent to \"--arg-kind directory\"")
+                              (kind-param 'directory)]
+   [("-c" "--collection-args") ("Interpet the arguments as collections"
+                                "Modules in collections are recursively checked"
+                                "Equivalent to \"--arg-kind collection\"")
+                               (kind-param 'collection)]
+   [("-p" "--package-args") ("Interpret the arguments as packages"
+                             "Modules in packages are recursively checked"
+                             "Equivalent to \"--arg-kind package\"")
+                            (kind-param 'package)]
+   #:once-each
+   [("-D" "--dry-run") "Don't actually write any fixes to files"
+                       (run-mode-param 'dry)]
+   #:args (arg . args)
+   (fix-args (module-args (kind-param) (cons arg args))
+             (run-mode-param))))
+
+(define (check-kind! k)
+  (unless (member k (list 'file 'directory 'collection 'package))
+    (raise-arguments-error
+     (string->symbol (short-program+command-name))
+     "expected an arg kind of file, directory, collection, or package"
+     "--arg-kind" k)))
+
+(define (write-module-count-message mod-count)
+  (match mod-count
+    [(== 0) (write-string "No modules found\n")]
+    [(== 1) (write-string "Checking 1 module\n")]
+    [num-modules (write-string (format "Checking ~a modules\n" num-modules))])
+  (flush-output))
+
+(define (write-warning-fix-message #:module-path mod
+                                   #:num-warnings num-warnings
+                                   #:num-fixes num-fixes
+                                   #:run-mode mode)
+  (unless (zero? num-fixes)
+    (define one-warning? (= num-warnings 1))
+    (define dry-run? (equal? mode 'dry))
+    (define message
+      (format "~a: ~a warning~a, ~a ~a\n"
+              mod
+              num-warnings
+              (if one-warning? "" "s")
+              (if dry-run? "would fix" "fixing")
+              (if one-warning? "" num-fixes)))
+    (write-string message)))
+
+(define (fix-warnings! args)
+  (match-define (fix-args mod-args mode) args)
+  (define mods (module-args->modules mod-args))
+  (write-module-count-message (length mods))
+  (for ([mod mods])
+    (define warnings (read-module-warnings mod))
+    (define warnings/fixes (filter syntax-warning/fix? warnings))
+    (write-warning-fix-message #:module-path mod
+                               #:num-warnings (length warnings)
+                               #:num-fixes (length warnings/fixes)
+                               #:run-mode mode)))
+
+(module+ main
+  (fix-warnings! (parse-warn-command!)))

--- a/syntax-warn/raco-warn.rkt
+++ b/syntax-warn/raco-warn.rkt
@@ -56,7 +56,6 @@
   (test-case "Formatted warning without a suggested fix"
     (define formatted-warning
       (format-warning (syntax-warning (syntax-srcloc #'here) "not there" #f)))
-    (check-string-contains? formatted-warning "raco-warn.rkt")
     (check-string-contains? formatted-warning "not there")
     (check-string-has-trailing-newline? formatted-warning))
   (test-case "Formatted warning with a suggested fix"
@@ -66,7 +65,7 @@
                       (suggested-fix #'foo #'bar)))
     (define expected-message-strings
       (list "----------------"
-            "raco-warn.rkt"
+            "L" "C"
             "use a different name"
             "foo"
             "suggested fix:"

--- a/syntax-warn/raco-warn.rkt
+++ b/syntax-warn/raco-warn.rkt
@@ -106,8 +106,8 @@
                              "Equivalent to \"--arg-kind package\"")
                             (kind-param 'package)]
    #:args (module-arg . module-args)
-   (warn-command-args (kind-param)
-                      (cons module-arg module-args))))
+   (module-args (kind-param)
+                (cons module-arg module-args))))
 
 (define (check-kind! k)
   (unless (member k (list 'file 'directory 'collection 'package))
@@ -115,19 +115,6 @@
      (string->symbol (short-program+command-name))
      "expected an arg kind of file, directory, collection, or package"
      "--arg-kind" k)))
-
-(struct warn-command-args
-  (kind module-args)
-  #:transparent)
-
-(define (warn-command-args->modules-to-check args)
-  (define kind (warn-command-args-kind args))
-  (define module-args (warn-command-args-module-args args))
-  (case kind
-    [(file) module-args]
-    [(directory) (append-map directory-warn-modules module-args)]
-    [(collection) (append-map collection-warn-modules module-args)]
-    [(package) (append-map package-warn-modules module-args)]))
 
 (define (warn-modules resolved-module-paths)
   (define any-warned? (box #f))
@@ -150,7 +137,7 @@
    (with-module-reading-parameterization read-modpath-expansion)))
   
 (module+ main
-  (define modules (warn-command-args->modules-to-check (parse-warn-command!)))
+  (define modules (module-args->modules (parse-warn-command!)))
   (match (length modules)
     [(== 0) (printf "No modules found\n")]
     [(== 1) (printf "Checking 1 module\n")]


### PR DESCRIPTION
Closes #3.
Closes #4.
Closes #5.
Closes #9.

Adds a `raco fix` command with similar switches to the `raco warn` command, that finds all syntax warnings in the specified modules and applies any suggested fixes to the files specified.
