### PR TITLE
Provide, document, and clean up module warnings API

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ before_install:
   - git clone https://github.com/greghendershott/travis-racket.git ../travis-racket
   - cat ../travis-racket/install-racket.sh | bash
   - 'export PATH="${RACKET_DIR}/bin:${PATH}"'
-  - '[[ $SKIP_COVER ]] || raco pkg install --auto cover cover-coveralls'
+  - '[[ $SKIP_COVER ]] || raco pkg install --auto cover cover-coveralls doc-coverage'
 install:
   - raco pkg install --auto
       $TRAVIS_BUILD_DIR/syntax-warn
@@ -23,6 +23,7 @@ install:
       $TRAVIS_BUILD_DIR/syntax-warn-test
 script:
   - raco test -p ${PACKAGES}
+  - raco doc-coverage warn
   - '[[ $SKIP_COVER ]] || raco cover -f coveralls -d $TRAVIS_BUILD_DIR/coverage -p ${PACKAGES}'
 after_success:
   - echo "Starting deploy"

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,8 @@ before_install:
   - git clone https://github.com/greghendershott/travis-racket.git ../travis-racket
   - cat ../travis-racket/install-racket.sh | bash
   - 'export PATH="${RACKET_DIR}/bin:${PATH}"'
-  - '[[ $SKIP_COVER ]] || raco pkg install --auto cover cover-coveralls doc-coverage'
+  - raco pkg install --auto doc-coverage
+  - '[[ $SKIP_COVER ]] || raco pkg install --auto cover cover-coveralls'
 install:
   - raco pkg install --auto
       $TRAVIS_BUILD_DIR/syntax-warn

--- a/syntax-warn/main.scrbl
+++ b/syntax-warn/main.scrbl
@@ -29,11 +29,6 @@ cause subtle bugs, and so on. Syntax warnings are first class values attached to
 source code at compile time through syntax properties, and can be inspected by
 other code and tools.
 
-@defstruct*[warning-kind ([name symbol?]) #:prefab]{
- Structure representing a warning kind. @warn-tech{Syntax warnings} often have
- similar sources and causes, and it can be helpful to group them under a warning
- kind. The @racket[name] of the warning kind is used for reporting.}
-
 @defproc[(syntax-warning [#:message message string?]
                          [#:kind kind warning-kind?]
                          [#:stx stx syntax?]
@@ -57,6 +52,15 @@ other code and tools.
    @defproc[(syntax-warning-stx [warning syntax-warning?]) syntax?]
    @defproc[(syntax-warning-fix [warning syntax-warning?]) (or/c syntax? #f)])]{
  Accessors for fields of @warn-tech{syntax warnings}.}
+
+@defstruct*[warning-kind ([name symbol?]) #:prefab]{
+ Structure representing a warning kind. @warn-tech{Syntax warnings} often have
+ similar sources and causes, and it can be helpful to group them under a warning
+ kind. The @racket[name] of the warning kind is used for reporting.}
+
+@defform[(define-warning-kind id)]{
+ Binds @racket[id] as a @racket[warning-kind] whose name is the quoted form of
+ @racket[id].}
 
 @defproc[(syntax-warn [stx syntax?]
                       [warning syntax-warning?])

--- a/syntax-warn/main.scrbl
+++ b/syntax-warn/main.scrbl
@@ -34,9 +34,6 @@ other code and tools.
  similar sources and causes, and it can be helpful to group them under a warning
  kind. The @racket[name] of the warning kind is used for reporting.}
 
-@defproc[(syntax-warning? [v any/c]) boolean?]{
- Predicate that recognizes @warn-tech{syntax warnings}.}
-
 @defproc[(syntax-warning [#:message message string?]
                          [#:kind kind warning-kind?]
                          [#:stx stx syntax?]
@@ -47,7 +44,19 @@ other code and tools.
  to use in place of @racket[stx]. If @racket[fix] is not provided, the warning
  makes no suggestions about how to resolve it.}
 
-@section{Attaching warnings to syntax}
+@defproc[(syntax-warning? [v any/c]) boolean?]{
+ Predicate that recognizes @warn-tech{syntax warnings}.}
+
+@defproc[(syntax-warning/fix? [v any/c]) boolean?]{
+ Predicate that recognizes @warn-tech{syntax warnings} that include a suggested
+ fix.}
+
+@deftogether[
+ (@defproc[(syntax-warning-message [warning syntax-warning?]) string?]
+   @defproc[(syntax-warning-kind [warning syntax-warning?]) warning-kind?]
+   @defproc[(syntax-warning-stx [warning syntax-warning?]) syntax?]
+   @defproc[(syntax-warning-fix [warning syntax-warning?]) (or/c syntax? #f)])]{
+ Accessors for fields of @warn-tech{syntax warnings}.}
 
 @defproc[(syntax-warn [stx syntax?]
                       [warning syntax-warning?])
@@ -65,3 +74,18 @@ other code and tools.
 @defproc[(syntax-warnings [stx syntax?]) (listof syntax?)]{
  Returns a list of all syntax warnings present in @racket[stx]. This includes
  syntax warnings in any syntax objects nested within @racket[stx].}
+
+@defproc[(read-syntax-warnings [#:input-port in input-port? (current-input-port)]
+                               [#:source-name source any/c (object-name in)]
+                               [#:namespace namespace namespace? (current-namespace)])
+         (listof syntax-warning?)]{
+ Constructs a syntax object from @racket[in] using @racket[read-syntax], fully
+ expands it using @racket[expand-syntax] in @racket[namespace], and returns a
+ list of all syntax warnings found in the fully expanded module.}
+
+@defproc[(read-syntax-warnings/file [filepath path-string?]
+                                    [#:namespace namespace namespace? (current-namespace)])
+         (listof syntax-warning?)]{
+ Like @racket[read-syntax-warnings], but reads @racket[filepath] as a module.
+ Sets the @racket[current-directory] to the directory part of @racket[filepath]
+ and uses @racket[filepath] as the source name.}

--- a/syntax-warn/raco-fix.rkt
+++ b/syntax-warn/raco-fix.rkt
@@ -131,8 +131,9 @@
   (match-define (fix-args mod-args mode) args)
   (define mods (module-args->modules mod-args))
   (write-module-count-message (length mods))
+  (define warnings-namespace (make-base-namespace))
   (for ([mod mods])
-    (define warnings (read-module-warnings mod))
+    (define warnings (read-syntax-warnings/file mod #:namespace warnings-namespace))
     (define warnings/fixes (filter syntax-warning/fix? warnings))
     (define deltas
       (prune-string-deltas (map syntax-warning/fix->string-delta warnings/fixes)))

--- a/syntax-warn/raco-warn.rkt
+++ b/syntax-warn/raco-warn.rkt
@@ -149,10 +149,13 @@
 
 (define (warn-modules resolved-module-paths)
   (define any-warned? (box #f))
+  (define warnings-namespace (make-base-namespace))
   (for ([modpath resolved-module-paths])
     (printf "raco warn: ~a\n" modpath)
     (flush-output)
-    (for ([warning (read-module-warnings modpath)])
+    (define warnings
+      (read-syntax-warnings/file modpath #:namespace warnings-namespace))
+    (for ([warning warnings])
       (set-box! any-warned? #t)
       (print-warning warning)))
   (unbox any-warned?))


### PR DESCRIPTION
Other miscellaneous grab bag fixes included:
1. Enforce doc coverage
2. Document define-warning-kind
3. Use a shared namespace for all modules expanded during a single use of the `raco warn` or `raco fix` commands
4. Split warning module reading into two functions: one working similarly to `read-syntax` and the other designed for reading a module file

Closes #40 
