### PR TITLE
Remove unnecessary base deps

### DIFF
--- a/syntax-warn-base/info.rkt
+++ b/syntax-warn-base/info.rkt
@@ -3,7 +3,8 @@
 (define version "0.1")
 (define collection "syntax")
 (define deps
-  '("rackunit-lib"
-    "typed-racket-lib"
-    ("base" #:version "6.4")))
-(define build-deps '("typed-racket-more"))
+  '(("base" #:version "6.4")))
+(define build-deps
+  '("rackunit-lib"))
+(define compile-omit-paths
+  '("warn/private"))

--- a/syntax-warn-base/warn/private/filter-index.rkt
+++ b/syntax-warn-base/warn/private/filter-index.rkt
@@ -1,11 +1,10 @@
-#lang typed/racket/base
+#lang racket/base
 
 (provide filter/index-result)
 
 (module+ test
-  (require typed/rackunit))
+  (require rackunit))
 
-(: filter/index-result (All (a) (-> (-> a Boolean) (Listof a) (Listof (List Integer a)))))
 (define (filter/index-result p vs)
   (for/list ([v vs] [i (in-naturals)] #:when (p v))
     (list i v)))

--- a/syntax-warn-base/warn/private/string-lines.rkt
+++ b/syntax-warn-base/warn/private/string-lines.rkt
@@ -1,4 +1,4 @@
-#lang typed/racket/base
+#lang racket/base
 
 (provide string-append-lines
          string-indent-lines
@@ -9,10 +9,9 @@
          racket/string)
 
 (module+ test
-  (require typed/rackunit))
+  (require rackunit))
 
 
-(: string-append-lines (->* () #:rest String String))
 (define (string-append-lines . strings)
   (apply string-append
          (add-between strings "\n")))
@@ -25,9 +24,7 @@
                 "foo\n\nbar")
   (check-equal? (string-append-lines) ""))
 
-(: string-indent-lines (-> String Nonnegative-Integer String))
 (define (string-indent-lines str n)
-  (: indent-line (-> String String))
   (define (indent-line line)
     (string-append (make-string n #\space) line))
   (lines->string (map indent-line (string->lines str))))
@@ -35,7 +32,6 @@
 (module+ test
   (check-equal? (string-indent-lines "foo\nbar" 2) "  foo\n  bar"))
 
-(: string->lines (-> String (Listof String)))
 (define (string->lines str)
   (if (equal? str "")
       (list "")
@@ -47,7 +43,6 @@
   (check-equal? (string->lines "") (list ""))
   (check-equal? (string->lines "\n") (list "" "")))
 
-(: lines->string (-> (Listof String) String))
 (define (lines->string lines)
   (string-join lines "\n"))
 

--- a/syntax-warn-base/warn/private/string-pad.rkt
+++ b/syntax-warn-base/warn/private/string-pad.rkt
@@ -1,16 +1,14 @@
-#lang typed/racket/base
+#lang racket/base
 
 (provide string-pad-right)
 
 (require racket/string)
 
 (module+ test
-  (require typed/rackunit))
+  (require rackunit))
 
 
-(: string-pad-right (-> String Char Nonnegative-Integer String))
 (define (string-pad-right str pad-char min-length)
-  (: num-below-minimum Nonnegative-Integer)
   (define num-below-minimum
     (max (- min-length (string-length str)) 0))
   (string-append str (make-string num-below-minimum pad-char)))


### PR DESCRIPTION
Removes syntax-warn-base dependencies on Typed Racket and runtime dependencies on RackUnit.

Closes #69 
