### PR TITLE
Fix raco command tests in package server

### DIFF
--- a/syntax-warn-cli/warn/private/test.rkt
+++ b/syntax-warn-cli/warn/private/test.rkt
@@ -1,6 +1,7 @@
 #lang racket/base
 
-(require racket/system)
+(require compiler/find-exe
+         racket/system)
 
 (module+ test
   (require rackunit
@@ -9,26 +10,26 @@
 
 (struct system-result (code stdout stderr) #:transparent)
 
-(define (system/result system-str)
+(define (raco command . args)
   (define stdout-str-port (open-output-string))
   (define stderr-str-port (open-output-string))
   (define exit-code
     (parameterize ([current-output-port stdout-str-port]
                    [current-error-port stderr-str-port])
-      (system/exit-code system-str)))
+      (apply system*/exit-code (find-exe) "-l" "raco" command args)))
   (define stdout (get-output-string stdout-str-port))
   (define stderr (get-output-string stderr-str-port))
   (system-result exit-code stdout stderr))
 
 (module+ test
   (test-case "Checking a module with no warnings"
-    (define result (system/result "raco warn -c syntax/warn/test-no-warnings"))
+    (define result (raco "warn" "-c" "syntax/warn/test-no-warnings"))
     (check-equal? (system-result-stderr result) "")
     (check-equal? (system-result-code result) 0)
     (check-string-contains? (system-result-stdout result)
                             "Checking 1 module\n"))
   (test-case "Checking a module with warnings"
-    (define result (system/result "raco warn -c syntax/warn/test-warnings"))
+    (define result (raco "warn" "-c" "syntax/warn/test-warnings"))
     (check-equal? (system-result-stderr result) "")
     (check-equal? (system-result-code result) 1)
     (check-string-contains-all? (system-result-stdout result)
@@ -39,7 +40,7 @@
                                       "require"
                                       "for-syntax")))
   (test-case "Fixing a module with no warnings"
-    (define result (system/result "raco fix -c syntax/warn/test-no-warnings"))
+    (define result (raco "fix" "-c" "syntax/warn/test-no-warnings"))
     (check-equal? (system-result-stderr result) "")
     (check-equal? (system-result-code result) 0)
     (define expected-stdout-strings
@@ -48,7 +49,7 @@
     (check-string-contains-all? (system-result-stdout result)
                                 expected-stdout-strings))
   (test-case "Fixing a module with warnings in dry run"
-    (define result (system/result "raco fix -cD syntax/warn/test-warnings"))
+    (define result (raco "fix" "-cD" "syntax/warn/test-warnings"))
     (check-equal? (system-result-stderr result) "")
     (check-equal? (system-result-code result) 0)
     (define expected-stdout-strings


### PR DESCRIPTION
Finding the racket executable and loading the raco module directly is
more stable than shelling out to “raco”, as the test environment might
not have the correct $PATH setup.